### PR TITLE
fix: skip messages without any lines specified

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -3976,6 +3976,13 @@ function analyzeESLintReport(lintedFiles) {
         warningCount += result.warningCount;
         // Loop through all the error/warning messages for the file
         for (const lintMessage of messages) {
+            /**
+             * A warning from ESLint doesn't return line and endline information
+             * https://eslint.org/docs/user-guide/configuring/ignoring-code#ignored-file-warnings
+             */
+            if (lintMessage.line === undefined) {
+                continue;
+            }
             // Pull out information about the error/warning message
             const { line, endLine, column, endColumn, severity, ruleId, message } = lintMessage;
             // Check if it a warning or error

--- a/src/analyze-eslint-js.ts
+++ b/src/analyze-eslint-js.ts
@@ -49,6 +49,14 @@ export default function analyzeESLintReport(lintedFiles: ESLintReport): Analyzed
 
     // Loop through all the error/warning messages for the file
     for (const lintMessage of messages) {
+      /**
+       * A warning from ESLint doesn't return line and endline information
+       * https://eslint.org/docs/user-guide/configuring/ignoring-code#ignored-file-warnings
+       */
+      if (lintMessage.line === undefined) {
+        continue;
+      }
+  
       // Pull out information about the error/warning message
       const { line, endLine, column, endColumn, severity, ruleId, message } = lintMessage;
 


### PR DESCRIPTION
Hi ! Thanks for your awesome action :) We encounter a problem when using the action in a huge monorepo where we lint only modified files. If you lint a file ignored in .eslintignore, ESLint send a warning without any line and endline.

https://eslint.org/docs/user-guide/configuring/ignoring-code#ignored-file-warnings

Action example:
```
jobs:
  lint:
    name: Lint
    steps:
      - id: files
        uses: mmagician/get-changed-files@1028587c8596c55a9d03d813a48aa1377f60b087
        with:
          format: 'json'
      - run: |
          ./node_modules/.bin/eslint -c .eslintrc.js --ext ts \
            --output-file eslint_report.json --format json \
            `jq -r '.[] | select(. | endswith(".ts")) | ..' <<< '${{ steps.files.outputs.added_modified }}`
```

Error from eslint-annotate-action:
`Error: Empty value for parameter 'output.annotations[1].end_line': undefined`