### PR TITLE
fix: use string template

### DIFF
--- a/src/eslint-json-report-to-js.ts
+++ b/src/eslint-json-report-to-js.ts
@@ -9,7 +9,7 @@ export default function ESLintJsonReportToJS(): ESLintReport {
   const report = core.getInput('report-json', { required: false }) || 'eslint_report.json';
   const reportPath = path.resolve(report);
   if (!fs.existsSync(reportPath)) {
-    core.setFailed('The report-json file "${report}" could not be resolved.');
+    core.setFailed(`The report-json file "${report}" could not be resolved.`);
   }
   const reportContents = fs.readFileSync(reportPath, 'utf-8');
   return JSON.parse(reportContents);


### PR DESCRIPTION
current error log is not clear.
Using string template it will display the configured path