### PR TITLE
Update inputs in action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,7 +1,7 @@
 name: "ESLint Annotate from Report JSON"
 description: "Annotates pull request diffs with warnings and errors from an ESLint report JSON file."
 inputs:
-  repo-token:
+  GITHUB_TOKEN:
     description: "The 'GITHUB_TOKEN' secret"
     default: ${{ github.token }}
     required: true


### PR DESCRIPTION
`repo-token` was renamed to `GITHUB_TOKEN`. This should be reflected in the `action.yml` file.