### PR TITLE
Allow lint warnings to result in neutral status conclusion

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,7 +1,9 @@
 {
   "printWidth": 120,
   "parser": "typescript",
-  "trailingComma": "es5",
+  "trailingComma": "all",
   "singleQuote": true,
+  "semi": false,
+  "bracketSpacing": false,
   "tabWidth": 2
 }

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ This allows for more flexibility on how ESLint is run. This action is agnostic e
 | `GITHUB_TOKEN` | The [`GITHUB_TOKEN` secret](https://docs.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token#about-the-github_token-secret) | No | `${{ github.token }}` |
 | `report-json` | Path or [glob pattern](https://github.com/actions/toolkit/tree/master/packages/glob) to locate the ESLint report JSON file. Use multiple lines to specify multiple glob patterns. | No | `eslint_report.json` |
 | `only-pr-files` | Only annotate files changed when run on the `pull_request` event | No | `true` |
-| `fail-on-warning` | Fail the GitHub Action when ESLint warnings are detected. Set to `true` to enable. | No | `false` |
+| `neutral-on-warning` | Set neutral result for the GitHub Action when ESLint warnings are detected. Set to `true` to enable. | No | `false` |
+| `fail-on-warning` | Fail the GitHub Action when ESLint warnings are detected. Set to `true` to enable. Overrides `fail-on-warning` | No | `false` |
 | `fail-on-error` | Whether to fail the Github action when ESLint errors are detected. If set to false, the check that is created will still fail on ESLint errors. | No | `true` |
 | `check-name` | The name of the GitHub status check created. | No | `ESLint Report Analysis` |
 | `markdown-report-on-step-summary` | Whether to show a markdown report in the step summary. | No | `false` |

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This allows for more flexibility on how ESLint is run. This action is agnostic e
 | `GITHUB_TOKEN` | The [`GITHUB_TOKEN` secret](https://docs.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token#about-the-github_token-secret) | No | `${{ github.token }}` |
 | `report-json` | Path or [glob pattern](https://github.com/actions/toolkit/tree/master/packages/glob) to locate the ESLint report JSON file. Use multiple lines to specify multiple glob patterns. | No | `eslint_report.json` |
 | `only-pr-files` | Only annotate files changed when run on the `pull_request` event | No | `true` |
-| `neutral-on-warning` | Set neutral result for the GitHub Action when ESLint warnings are detected. Set to `true` to enable. | No | `false` |
+| `neutral-on-warning` | Set neutral result for the check when ESLint warnings are detected. Set to `true` to enable. | No | `false` |
 | `fail-on-warning` | Fail the GitHub Action when ESLint warnings are detected. Set to `true` to enable. Overrides `fail-on-warning` | No | `false` |
 | `fail-on-error` | Whether to fail the Github action when ESLint errors are detected. If set to false, the check that is created will still fail on ESLint errors. | No | `true` |
 | `check-name` | The name of the GitHub status check created. | No | `ESLint Report Analysis` |

--- a/action.yml
+++ b/action.yml
@@ -13,8 +13,12 @@ inputs:
     description: "Only annotate files changed when run on the 'pull_request' event"
     default: 'true'
     required: false
+  neutral-on-warning:
+    description: "Set neutral result for the GitHub Action when ESLint warnings are detected. Set to 'true' to enable."
+    default: 'false'
+    required: false
   fail-on-warning:
-    description: "Fail the GitHub Action when ESLint warnings are detected. Set to 'true' to enable."
+    description: "Fail the GitHub Action when ESLint warnings are detected. Set to 'true' to enable. Overrides 'neutral-on-warning'."
     default: 'false'
     required: false
   fail-on-error:

--- a/dist/index.js
+++ b/dist/index.js
@@ -56149,6 +56149,7 @@ function getBooleanInput(inputName, defaultValue) {
 }
 function getInputs() {
     const onlyChangedFiles = getBooleanInput('only-pr-files', 'true');
+    const neutralOnWarning = getBooleanInput('neutral-on-warning', 'false');
     const failOnWarning = getBooleanInput('fail-on-warning', 'false');
     const failOnError = getBooleanInput('fail-on-error', 'true');
     const markdownReportOnStepSummary = getBooleanInput('markdown-report-on-step-summary', 'false');
@@ -56158,6 +56159,7 @@ function getInputs() {
         : core.getInput('report-json', { required: true });
     return {
         onlyChangedFiles,
+        neutralOnWarning,
         failOnWarning,
         failOnError,
         markdownReportOnStepSummary,
@@ -56165,7 +56167,7 @@ function getInputs() {
         reportFile,
     };
 }
-const { onlyChangedFiles, failOnWarning, failOnError, markdownReportOnStepSummary, checkName, reportFile } = getInputs();
+const { onlyChangedFiles, neutralOnWarning, failOnWarning, failOnError, markdownReportOnStepSummary, checkName, reportFile, } = getInputs();
 // https://github.com/eslint/eslint/blob/a59a4e6e9217b3cc503c0a702b9e3b02b20b980d/lib/linter/apply-disable-directives.js#L253
 const unusedDirectiveMessagePrefix = 'Unused eslint-disable directive';
 const getTimestamp = () => {
@@ -56188,6 +56190,7 @@ exports["default"] = {
     isPullRequest,
     isGitHubActions,
     getTimestamp,
+    neutralOnWarning,
     failOnWarning,
     failOnError,
     markdownReportOnStepSummary,
@@ -56302,7 +56305,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 const constants_1 = __importDefault(__nccwpck_require__(9042));
-const { core, GITHUB_WORKSPACE, OWNER, REPO, SHA, failOnWarning, unusedDirectiveMessagePrefix } = constants_1.default;
+const { core, GITHUB_WORKSPACE, OWNER, REPO, SHA, neutralOnWarning, failOnWarning, unusedDirectiveMessagePrefix } = constants_1.default;
 /**
  * Analyzes an ESLint report JS object and returns a report
  * @param files a JavaScript representation of an ESLint JSON report
@@ -56405,7 +56408,13 @@ function getAnalyzedReport(files) {
         markdownText += warningText + '\n';
     }
     let success = errorCount === 0;
+    let conclusion = success ? 'success' : 'failure';
+    if (neutralOnWarning && warningCount > 0) {
+        conclusion = 'neutral';
+        success = false;
+    }
     if (failOnWarning && warningCount > 0) {
+        conclusion = 'failure';
         success = false;
     }
     // Return the ESLint report analysis
@@ -56414,6 +56423,7 @@ function getAnalyzedReport(files) {
         warningCount,
         markdown: markdownText,
         success,
+        conclusion,
         summary: `${errorCount} ESLint error(s) and ${warningCount} ESLint warning(s) found`,
         annotations,
     };
@@ -56471,6 +56481,7 @@ async function getPullRequestChangedAnalyzedReport(reportJS) {
         warningCount: analyzedPullRequestReport.warningCount,
         markdown,
         success: analyzedPullRequestReport.success,
+        conclusion: analyzedPullRequestReport.conclusion,
         summary,
         annotations: analyzedPullRequestReport.annotations,
     };
@@ -56561,7 +56572,7 @@ async function run() {
         ? await (0, getPullRequestChangedAnalyzedReport_1.default)(reportJS)
         : (0, getAnalyzedReport_1.default)(reportJS);
     const annotations = analyzedReport.annotations;
-    const conclusion = analyzedReport.success ? 'success' : 'failure';
+    const conclusion = analyzedReport.conclusion;
     core.info(analyzedReport.summary);
     core.setOutput('summary', analyzedReport.summary);
     core.setOutput('errorCount', analyzedReport.errorCount);

--- a/src/__tests__/eslintReport-1-error-analyzed.ts
+++ b/src/__tests__/eslintReport-1-error-analyzed.ts
@@ -24,6 +24,7 @@ const reportAnalyzedExpected: AnalyzedESLintReport = {
     '  - From: [`no-sequences`]\n' +
     '\n',
   success: false,
+  conclusion: 'failure',
   summary: '3 ESLint error(s) and 0 ESLint warning(s) found',
   annotations: [
     {

--- a/src/__tests__/eslintReport-3-errors-analyzed.ts
+++ b/src/__tests__/eslintReport-3-errors-analyzed.ts
@@ -24,6 +24,7 @@ const reportAnalyzedExpected: AnalyzedESLintReport = {
     '  - From: [`prettier/prettier`]\n' +
     '\n',
   success: false,
+  conclusion: 'failure',
   summary: '3 ESLint error(s) and 0 ESLint warning(s) found',
   annotations: [
     {

--- a/src/__tests__/eslintReport-unused-eslint-disable-directive-analyzed.ts
+++ b/src/__tests__/eslintReport-unused-eslint-disable-directive-analyzed.ts
@@ -5,7 +5,8 @@ import {AnalyzedESLintReport} from '../types'
 const reportAnalyzedExpected: AnalyzedESLintReport = {
   errorCount: 1,
   warningCount: 0,
-  markdown: '## 1 Error(s):\n' +
+  markdown:
+    '## 1 Error(s):\n' +
     '### [`src/index.ts` line `10`](https://github.com/ataylorme/eslint-annotate-github-action/blob/8e80ec28fec6ef9763aacbabb452bcb5d92315ca/src/index.ts#L10:L10)\n' +
     '- Start Line: `10`\n' +
     '- End Line: `10`\n' +
@@ -13,6 +14,7 @@ const reportAnalyzedExpected: AnalyzedESLintReport = {
     '  - From: [`null`]\n' +
     '\n',
   success: false,
+  conclusion: 'failure',
   summary: '1 ESLint error(s) and 0 ESLint warning(s) found',
   annotations: [
     {
@@ -20,11 +22,12 @@ const reportAnalyzedExpected: AnalyzedESLintReport = {
       start_line: 10,
       end_line: 10,
       annotation_level: 'failure',
-      message: "[null] Unused eslint-disable directive (no problems were reported from '@typescript-eslint/no-unused-vars').",
+      message:
+        "[null] Unused eslint-disable directive (no problems were reported from '@typescript-eslint/no-unused-vars').",
       start_column: 3,
-      end_column: 3
-    }
-  ]
+      end_column: 3,
+    },
+  ],
 }
 
 /* eslint-enable */

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -37,6 +37,7 @@ function getBooleanInput(inputName: string, defaultValue: string): boolean {
 
 function getInputs() {
   const onlyChangedFiles = getBooleanInput('only-pr-files', 'true')
+  const neutralOnWarning = getBooleanInput('neutral-on-warning', 'false')
   const failOnWarning = getBooleanInput('fail-on-warning', 'false')
   const failOnError = getBooleanInput('fail-on-error', 'true')
   const markdownReportOnStepSummary = getBooleanInput('markdown-report-on-step-summary', 'false')
@@ -47,6 +48,7 @@ function getInputs() {
 
   return {
     onlyChangedFiles,
+    neutralOnWarning,
     failOnWarning,
     failOnError,
     markdownReportOnStepSummary,
@@ -55,7 +57,15 @@ function getInputs() {
   }
 }
 
-const {onlyChangedFiles, failOnWarning, failOnError, markdownReportOnStepSummary, checkName, reportFile} = getInputs()
+const {
+  onlyChangedFiles,
+  neutralOnWarning,
+  failOnWarning,
+  failOnError,
+  markdownReportOnStepSummary,
+  checkName,
+  reportFile,
+} = getInputs()
 
 // https://github.com/eslint/eslint/blob/a59a4e6e9217b3cc503c0a702b9e3b02b20b980d/lib/linter/apply-disable-directives.js#L253
 const unusedDirectiveMessagePrefix = 'Unused eslint-disable directive'
@@ -81,6 +91,7 @@ export default {
   isPullRequest,
   isGitHubActions,
   getTimestamp,
+  neutralOnWarning,
   failOnWarning,
   failOnError,
   markdownReportOnStepSummary,

--- a/src/getAnalyzedReport.ts
+++ b/src/getAnalyzedReport.ts
@@ -1,6 +1,7 @@
 import type {ESLintReport, ChecksUpdateParamsOutputAnnotations, AnalyzedESLintReport} from './types'
 import constants from './constants'
-const {core, GITHUB_WORKSPACE, OWNER, REPO, SHA, failOnWarning, unusedDirectiveMessagePrefix} = constants
+const {core, GITHUB_WORKSPACE, OWNER, REPO, SHA, neutralOnWarning, failOnWarning, unusedDirectiveMessagePrefix} =
+  constants
 
 /**
  * Analyzes an ESLint report JS object and returns a report
@@ -123,7 +124,13 @@ export default function getAnalyzedReport(files: ESLintReport): AnalyzedESLintRe
   }
 
   let success = errorCount === 0
-  if (failOnWarning && warningCount > 0) {
+  let conclusion = success ? 'success' : 'failure'
+
+  if (neutralOnWarning && warningCount > 0) {
+    conclusion = 'neutral'
+    success = false
+  } else if (failOnWarning && warningCount > 0) {
+    conclusion = 'failure'
     success = false
   }
 
@@ -133,6 +140,7 @@ export default function getAnalyzedReport(files: ESLintReport): AnalyzedESLintRe
     warningCount,
     markdown: markdownText,
     success,
+    conclusion,
     summary: `${errorCount} ESLint error(s) and ${warningCount} ESLint warning(s) found`,
     annotations,
   }

--- a/src/getAnalyzedReport.ts
+++ b/src/getAnalyzedReport.ts
@@ -135,8 +135,6 @@ export default function getAnalyzedReport(files: ESLintReport): AnalyzedESLintRe
     success = false
   }
 
-  core.info(`Conclusion ${conclusion}`)
-
   // Return the ESLint report analysis
   return {
     errorCount,

--- a/src/getAnalyzedReport.ts
+++ b/src/getAnalyzedReport.ts
@@ -129,10 +129,13 @@ export default function getAnalyzedReport(files: ESLintReport): AnalyzedESLintRe
   if (neutralOnWarning && warningCount > 0) {
     conclusion = 'neutral'
     success = false
-  } else if (failOnWarning && warningCount > 0) {
+  }
+  if (failOnWarning && warningCount > 0) {
     conclusion = 'failure'
     success = false
   }
+
+  core.info(`Conclusion ${conclusion}`)
 
   // Return the ESLint report analysis
   return {

--- a/src/getPullRequestChangedAnalyzedReport.ts
+++ b/src/getPullRequestChangedAnalyzedReport.ts
@@ -9,7 +9,7 @@ const {GITHUB_WORKSPACE, OWNER, REPO, pullRequest, onlyChangedFiles} = constants
  * @param reportJS a JavaScript representation of an ESLint JSON report
  */
 export default async function getPullRequestChangedAnalyzedReport(
-  reportJS: ESLintReport,
+  reportJS: ESLintReport
 ): Promise<AnalyzedESLintReport> {
   const changedFiles = await getPullRequestFiles({
     owner: OWNER,
@@ -48,6 +48,7 @@ export default async function getPullRequestChangedAnalyzedReport(
     warningCount: analyzedPullRequestReport.warningCount,
     markdown,
     success: analyzedPullRequestReport.success,
+    conclusion: analyzedPullRequestReport.conclusion,
     summary,
     annotations: analyzedPullRequestReport.annotations,
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ async function run(): Promise<void> {
     ? await getPullRequestChangedAnalyzedReport(reportJS)
     : getAnalyzedReport(reportJS)
   const annotations = analyzedReport.annotations
-  const conclusion = analyzedReport.success ? 'success' : 'failure'
+  const conclusion = analyzedReport.conclusion
 
   core.info(analyzedReport.summary)
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -52,6 +52,7 @@ export interface AnalyzedESLintReport {
   errorCount: number
   warningCount: number
   success: boolean
+  conclusion: string
   markdown: string
   summary: string
   annotations: ChecksUpdateParamsOutputAnnotations[]


### PR DESCRIPTION
When `fail-on-warning` is not set, lint warnings can be hard to spot if one just looks at the PR summary and does not click through, because the check is shown as success.

This PR adds an option `neutral-on-warning` that will set the check conclusion as neutral. This will can make lint warnings more noticable, without counting as a check failure.

![Screenshot 2025-01-08 at 16 27 49](https://github.com/user-attachments/assets/4e97abff-a7f1-4fcb-927b-9dd67aa5fd9a)

Setting the existing setting `fail-on-warning` to true overrides `neutral-on-warning`.